### PR TITLE
fix: add yaml to ignore loader

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -67,7 +67,7 @@ export default {
 
     extend (config, { isDev, isClient }) {
       config.module.rules.push({
-        test: /\.md$/i,
+        test: /\.(md|yaml)$/i,
         loader: 'ignore-loader'
       })
     }


### PR DESCRIPTION
Supresses errors by webpack about unexpected tokens in the YAML files