### PR TITLE
Change container width to be smaller on blog posts

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -6,6 +6,7 @@ html {
   --color-text: rgb(255, 255, 255);
   --color-text-dark: rgb(172, 172, 172);
   --max-width-lg: 1100px;
+  --max-width-blog: 900px;
 
   scroll-behavior: smooth;
 }

--- a/components/PageContainer.vue
+++ b/components/PageContainer.vue
@@ -1,8 +1,21 @@
 <template>
-  <div class="container">
+  <div
+    class="container"
+    :class="{ 'container--blog': blog }"
+  >
     <slot />
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    blog: {
+      type: Boolean
+    }
+  }
+}
+</script>
 
 <style lang="scss" scoped>
 .container {
@@ -10,5 +23,9 @@
   width: 100%;
   margin: 0 auto;
   padding: 4vmin;
+
+  &--blog {
+    max-width: var(--max-width-blog);
+  }
 }
 </style>

--- a/pages/blog/_slug.vue
+++ b/pages/blog/_slug.vue
@@ -6,7 +6,7 @@
       :image="bannerImage"
       :color="post.headerColor"
     />
-    <PageContainer>
+    <PageContainer blog>
       <nuxt-content
         class="blogPost__post"
         :document="post"


### PR DESCRIPTION
More readability changes that somewhat go with #13, this shortens the container width on blog posts by about 200px, but this can be changed with the `--max-width-blog` variable in `main.scss`.

This brings the article layout more in line with what you would see on other blog/article sites. The container size could potentially go even lower, but I think the 900px it's at at the moment should be the max.