### PR TITLE
Layout and image fixes

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -427,6 +427,7 @@ export default {
     color: var(--color-text);
     font-weight: 600;
     padding: 0.5em 1em;
+    white-space: nowrap;
     transition: text-shadow 0.2s ease, transform 0.2s ease;
     width: max-content;
 

--- a/components/global/LazyImage.vue
+++ b/components/global/LazyImage.vue
@@ -37,13 +37,22 @@ export default {
 
   methods: {
     getImage () {
-      try {
+      if (this.src.startsWith('http')) {
         return {
-          image: require(`~/content/${this.$route.path.substring(1)}/img/${this.src}`),
-          placeholder: require(`~/content/${this.$route.path.substring(1)}/img/${this.src}?lqip`)
+          image: this.src
         }
-      } catch (err) {
-        return null
+      } else {
+        const { document } = this.$parent
+        const blogRoot = document.dir.substring(1).substr(0, document.dir.lastIndexOf('/') - 1)
+
+        try {
+          return {
+            image: require(`~/content/${blogRoot}/img/${this.src}`),
+            placeholder: require(`~/content/${blogRoot}/img/${this.src}?lqip`)
+          }
+        } catch (err) {
+          return null
+        }
       }
     }
   }

--- a/content/blog/2020-12-17-cyberpunk-update-no1/locales/cn.md
+++ b/content/blog/2020-12-17-cyberpunk-update-no1/locales/cn.md
@@ -21,7 +21,7 @@ createdAt: 2020-12-17
 1. GUI，每个人都可以使用的界面。在这里，您可以在线查找mod，并手动或通过我们自己的Mod站点进行安装。 （我们尚未与nexus mod保持联系，但我们正在寻找一种方法，可能将它们集成！）通过我们的简单GUI设计，即使是从未进行过修改的用户也可以通过按一下按钮轻松地安装新的mod。我们目前正在研究设计本身，并拥有一个原型，它依赖于nexus的RapidDevs ModManager设计。 ！ NEXUS上的模组管理器不是我们的！
 （更多在这里）
 
-<img style="width:100%;" src="https://preview.redd.it/6yx3phhhzq561.png?width=1347&format=png&auto=webp&s=c6909626fe33ab9b2f782397784abe17dbfb3bc8">
+<lazy-image src="https://preview.redd.it/6yx3phhhzq561.png?width=1347&format=png&auto=webp&s=c6909626fe33ab9b2f782397784abe17dbfb3bc8">
 
 2. GPM或游戏包管理器是用于mod管理的CLI，负责安装，构建，发布和下载mod包。它基本上是骨干，以及我们将用来修改游戏的内容。
 

--- a/content/blog/2020-12-17-cyberpunk-update-no1/locales/fr.md
+++ b/content/blog/2020-12-17-cyberpunk-update-no1/locales/fr.md
@@ -21,11 +21,9 @@ Comment cela va-t-il fonctionner ? Le gestionnaire de mods va être séparé en 
 1. L'interface graphique, une interface avec laquelle tout le monde peut travailler. Jusqu'ici, vous recherchez des mods en ligne et installez-les manuellement, ou via notre propre site Mod. (Nous n'avons pas encore été en contact avec les mods nexus, mais nous cherchons un moyen pour peut-être les intégrer !) Avec notre conception d'interface graphique facile, même ceux qui n'ont jamais modifié un jeu peuvent installer de nouveaux mods facilement en appuyant simplement sur un bouton. Nous travaillons actuellement sur la conception de celle-ci, avec un prototype, en nous appuyant sur la conception du ModManager de RapidDevs de nexus. ! LE GESTIONNAIRE DE MOD SUR NEXUS N'EST PAS LE NOTRE !
 (Plus ici)
 
-<img style="width:100%;" src="https://preview.redd.it/6yx3phhhzq561.png?width=1347&format=png&auto=webp&s=c6909626fe33ab9b2f782397784abe17dbfb3bc8">
+<lazy-image src="https://preview.redd.it/6yx3phhhzq561.png?width=1347&format=png&auto=webp&s=c6909626fe33ab9b2f782397784abe17dbfb3bc8"></lazy-image>
 
 2. Le GPM ou Game Package Manager est un CLI pour la gestion des mods, responsable de l'installation, de la construction, de la publication et du téléchargement des packages de mods. C'est la base de que nous allons utiliser pour modifier le jeu.
-
-
 
 Nous faisons actuellement tellement de choses à la fois, qu'il n'est même pas possible pour nous de le lister ici, donc si cela vous intéresse, n'hésitez pas à rejoindre notre Discord et à interagir avec plus de 4,5 milles personnes intéressées par le modding ou aidez-nous dans divers sujets allant de la rétro-ingénierie au niveau de la mémoire jusqu'à la maîtrise de modèles et texture ! Nous accueillons tout le monde !
 

--- a/content/blog/2020-12-17-cyberpunk-update-no1/locales/jp.md
+++ b/content/blog/2020-12-17-cyberpunk-update-no1/locales/jp.md
@@ -21,9 +21,9 @@ Mod Manager
 1. GUI、誰もが操作できるインターフェイス。 ここでは、オンラインでModを探して手動でインストールするか、独自のModサイトを介してインストールします。 （私たちはまだnexus modsと連絡を取り合っていませんが、おそらくそれらを統合する方法を探しています！）簡単なGUIデザインで、改造したことがない人でもボタンを押すだけで新しいmodを簡単にインストールできます。 現在、ネクサスのRapidDevs ModManager設計に基づいて、プロトタイプを作成し、設計自体に取り組んでいます。 ！ NEXUSのMODマネージャーは米国ではありません！
 （詳細はこちら）
 
-<img style="max-width:100%;" src="https://preview.redd.it/6yx3phhhzq561.png?width=1347&format=png&auto=webp&s=c6909626fe33ab9b2f782397784abe17dbfb3bc8">
+<lazy-image src="https://preview.redd.it/6yx3phhhzq561.png?width=1347&format=png&auto=webp&s=c6909626fe33ab9b2f782397784abe17dbfb3bc8">
 
-2. GPMまたはゲームパッケージマネージャーは、Mod管理用のCLIであり、Modパッケージのインストール、ビルド、公開、ダウンロードを担当します。 これは基本的にバックボーンであり、ゲームを改造するために使用するものです。
+1. GPMまたはゲームパッケージマネージャーは、Mod管理用のCLIであり、Modパッケージのインストール、ビルド、公開、ダウンロードを担当します。 これは基本的にバックボーンであり、ゲームを改造するために使用するものです。
 
 
 

--- a/pages/team/-components/TeamMember.vue
+++ b/pages/team/-components/TeamMember.vue
@@ -127,8 +127,7 @@ export default {
   display: flex;
   align-items: center;
   margin-bottom: 2em;
-  width: 45%;
-  min-width: 400px;
+  width: 100%;
 
   &__imageContainer,
   &__imageContainerNone {
@@ -178,6 +177,7 @@ export default {
   &__personalInfo {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
   }
 
   &__name {
@@ -185,6 +185,7 @@ export default {
     font-weight: 600;
     margin-bottom: 0.25em;
     margin-right: 0.5em;
+    word-break: break-all;
   }
 
   &__socials {

--- a/pages/team/index.vue
+++ b/pages/team/index.vue
@@ -170,9 +170,17 @@ export default {
   }
 
   &__list {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    // flex-wrap: wrap;
+    // justify-content: space-between;
+  }
+
+  @media (max-width: 1100px) {
+    &__list {
+      display: grid;
+      grid-template-columns: 1fr;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Fixes overflow issue on team page to do with min-width attribute. Page is now laid out with CSS grid and will shrink down to one column once the page is the same size as the site container max width.

Fix nav dropdown items breaking text, although this issue shouldn't have happened in the first place if the page didn't overflow. Added nowrap just in case though, never know it'll do.

Added a check on the `lazy-image` component to see if a http link has been given to it. Also fixed the pathing issue that now exists because of the i18n module adding the locale code to the url, component now correctly gets the blog directory to load images from.

Changed existing blog posts to use the lazy image component.